### PR TITLE
Disable google repository for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,20 @@ jobs:
       name: "Unit Tests"              
       before_install:
         - ".travis/before-install.sh"
-      script: mvn verify -B
+      script: mvn -s .travis/mavenSettings.xml verify -B
       install: skip
       after_success:
         - java -jar ~/codacy-coverage-reporter-assembly.jar report -l Java -r ktapi-report/target/site/jacoco-aggregate/jacoco.xml
         - bash <(curl -s https://codecov.io/bash)
     - name: "Spotbugs"
-      script: mvn spotbugs:check -B
+      install: mvn install  -s .travis/mavenSettings.xml -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+      script: mvn -s .travis/mavenSettings.xml spotbugs:check -B
     - name: "Checkstyle"
-      script: mvn checkstyle:check -B
+      install: mvn install  -s .travis/mavenSettings.xml -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+      script: mvn -s .travis/mavenSettings.xml checkstyle:check -B
     - name: "License"
-      script: mvn license:check -B
+      install: mvn install  -s .travis/mavenSettings.xml -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+      script: mvn -s .travis/mavenSettings.xml license:check -B
     - stage: deploy
       name: "Deploy to Github"
       if: tag IS true AND repo = "125m125/ktapi-java"

--- a/.travis/mavenSettings.xml
+++ b/.travis/mavenSettings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <mirrors>
+        <mirror>
+            <id>maven-central</id>
+            <name>Maven Central</name>
+            <url>http://repo1.maven.org/maven2</url>
+            <mirrorOf>central</mirrorOf>
+        </mirror>
+    </mirrors>
+</settings>


### PR DESCRIPTION
The google maven repository seems to update too slow for dependabot, which caused a lot of false negatives during the builds.