### PR TITLE
fix https error in mavenSettings

### DIFF
--- a/.travis/mavenSettings.xml
+++ b/.travis/mavenSettings.xml
@@ -6,7 +6,7 @@
         <mirror>
             <id>maven-central</id>
             <name>Maven Central</name>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
             <mirrorOf>central</mirrorOf>
         </mirror>
     </mirrors>


### PR DESCRIPTION
Maven discontinued access to the repo over normal http. This pull-request fixes this by using https.